### PR TITLE
添加scipy依赖，防止运行报错

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ bitsandbytes==0.39.0
 loguru==0.7.0
 numpy==1.21.4
 pandas==1.2.5
+scipy
 tqdm==4.62.3
 deepspeed==0.9.5
 tensorboard


### PR DESCRIPTION
这个项目依赖`scipy`，但是pip安装时不会安装它